### PR TITLE
Temporarly disable the Discord bot

### DIFF
--- a/base/kustomization.yaml
+++ b/base/kustomization.yaml
@@ -23,4 +23,4 @@ resources:
   - auth/deployment.yaml
   - auth/service.yaml
   - auth/ingress.yaml
-  - discord-bot/deployment.yaml
+  # - discord-bot/deployment.yaml


### PR DESCRIPTION
The Discord bot is causing (I'm fairly sure, at least given the data I have access to) a lot of issues with the ZDV site. I've already tried increasing the resources available to the API k8s pod in that deployment (https://github.com/kzdv/gitops, https://github.com/kzdv/gitops/pull/13) and that resolved an OOM kill from k8s shown in Argo, but the bot is still spamming the roster API endpoint, which is the most expensive endpoint in the site, which seems to be causing the site to get overloaded and fail to respond to k8s' health checks. Clearly, this results in k8s killing the pod, leading to frequent (every 5-90 minutes) pod restarts and website downtime.

I'm not sure if this will bring the bot down for everyone, or just ZDV. Seems like everyone?