### PR TITLE
Add Docker build caching

### DIFF
--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -12,22 +12,26 @@ jobs:
     build:
       runs-on: ubuntu-latest
       steps:
-        # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
-        - name: Build Docker Image
-          run: docker build . --file ${{ inputs.relative-path }}Dockerfile --tag vatusa/${{ inputs.image-name }} --target app
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
 
         - name: Log in to Docker Hub
-          uses: docker/login-action@v1
+          uses: docker/login-action@v3
           with:
             username: ${{ secrets.DOCKER_USERNAME }}
             password: ${{ secrets.DOCKER_PASSWORD }}
 
-        - name: Push to Docker Hub (main)
-          run: |
-            docker tag vatusa/${{ inputs.image-name }} vatusa/${{ inputs.image-name }}:latest
-            docker tag vatusa/${{ inputs.image-name }} vatusa/${{ inputs.image-name }}:${{ github.sha }}
-            docker push vatusa/${{ inputs.image-name }}:latest
-            docker push vatusa/${{ inputs.image-name }}:${{ github.sha }}
-            
+        - name: Build and push Docker image
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            file: ${{ inputs.relative-path }}Dockerfile
+            target: app
+            push: true
+            tags: |
+              vatusa/${{ inputs.image-name }}:latest
+              vatusa/${{ inputs.image-name }}:${{ github.sha }}
+            cache-from: type=gha,scope=${{ inputs.image-name }}
+            cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}


### PR DESCRIPTION
## Add Docker layer caching to common-build workflow

### What changed

Replaced the manual `docker build` / `docker tag` / `docker push` sequence in `common-build.yml` with `docker/build-push-action@v5` backed by GitHub Actions cache (`type=gha`). BuildKit is now explicitly enabled via `docker/setup-buildx-action@v3`, which is required for the cache backend and also unlocks the `--mount=type=cache` directives already present in the portal and staff Dockerfiles (those mounts were silently ignored before this change). Also bumped `actions/checkout@v2 → @v4` and `docker/login-action@v1 → @v3`.

### Why

Every run previously pulled the base image fresh and re-executed every Dockerfile layer from scratch. For Node.js (portal/staff) and Rust (mithril) builds in particular, dependency installation is the dominant cost — this change lets unchanged layers restore from cache instead of being rebuilt.

### Multi-app support

The workflow accepts an `image-name` input and passes it as the `scope` parameter to the GHA cache backend:

```yaml
cache-from: type=gha,scope=${{ inputs.image-name }}
cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}
```

This means each image (`portal`, `staff`, `cobalt`, `mithril`) maintains its own isolated cache partition. The webapps repo, which calls this workflow twice in the same pipeline, will not have portal and staff cache entries colliding or evicting each other.

### Storage limits & billing

GitHub Actions cache storage is **free up to 10 GB per repository** on all plans (Free, Team, Enterprise). The budget is charged to the **caller repo**, not this gitops repo — so webapps, cobalt, and mithril each get their own independent 10 GB allotment. There are no overage charges; if a repo exceeds 10 GB, GitHub evicts least-recently-used entries automatically. Cache entries not accessed within 7 days are also evicted. Cache storage and retrieval do not consume Actions compute minutes.

The one repo to watch is mithril (Rust): cargo caches can grow large (5–20 GB depending on the dependency tree). Mithril's Dockerfile already uses the dummy-`main.rs` trick to isolate cargo dependencies as a separate layer, so the GHA cache will still help, but it's worth keeping an eye on cache size in the Actions → Caches tab of that repo.

### Verification

After merging, trigger any build that calls this workflow. On the second run, the `Build and push Docker image` step will log layer cache hits. Check **Actions → Caches** in the caller repo to see entries keyed by scope (e.g., `buildx-Linux-portal`, `buildx-Linux-staff`, `buildx-Linux-cobalt`).